### PR TITLE
Fix .travis.yaml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-install: pip install -U tox-travis
+install: pip install -U tox-travis coveralls
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
@@ -26,4 +26,7 @@ matrix:
 
 script:
   - tox
+
+after_success:
+  - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
-python:
-- 3.6
-- 3.7
 install: pip install -U tox-travis
-script: tox
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
@@ -14,4 +10,23 @@ deploy:
     tags: true
     repo: marcofavorito/temprl
     python: 3.6
-  
+matrix:
+  include:
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.7
+      env: TOXENV=flake8
+    - python: 3.7
+      env: TOXENV=mypy
+    - python: 3.7
+      env: TOXENV=docs
+
+	- python: 3.6
+	  env: TOXENV=py36
+
+install:
+  - ./.travis/install
+
+script:
+  - ./.travis/run tox
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
     - python: 3.6
       env: TOXENV=py36
 
-install:
-  - ./.travis/install
-
 script:
-  - ./.travis/run tox
+  - tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
     - python: 3.7
       env: TOXENV=docs
 
-	- python: 3.6
-	  env: TOXENV=py36
+    - python: 3.6
+      env: TOXENV=py36
 
 install:
   - ./.travis/install

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![](https://img.shields.io/pypi/v/temprl.svg)](https://pypi.python.org/pypi/temprl)
 [![](https://img.shields.io/travis/sapienza-rl/temprl.svg)](https://travis-ci.org/sapienza-rl/temprl)
-[![](https://readthedocs.org/projects/temprl/badge/?version=latest)](https://temprl.readthedocs.io/en/latest/?badge=latest)
-[![](https://badges.gitter.im/rltg_flloat/Lobby.svg)](https://gitter.im/rltg_flloat/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Framework for Reinforcement Learning with Temporal Goals defined by LTLf/LDLf formulas.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![](https://img.shields.io/pypi/v/temprl.svg)](https://pypi.python.org/pypi/temprl)
 [![](https://img.shields.io/travis/sapienza-rl/temprl.svg)](https://travis-ci.org/sapienza-rl/temprl)
+[![](https://img.shields.io/badge/python-3.6%20%7C%203.7-blue)](https://img.shields.io/badge/python-3.6%20%7C%203.7-blue)
+[![](https://coveralls.io/repos/github/sapienza-rl/temprl/badge.svg?branch=master)](https://coveralls.io/github/sapienza-rl/temprl?branch=master)
+[![](https://img.shields.io/badge/flake8-checked-blueviolet)](https://img.shields.io/badge/flake8-checked-blueviolet)
+[![](https://img.shields.io/badge/mypy-checked-blue)](https://img.shields.io/badge/mypy-checked-blue)
+[![](https://img.shields.io/badge/license-Apache%202-lightgrey)](https://img.shields.io/badge/license-Apache%202-lightgrey)
+
 
 Framework for Reinforcement Learning with Temporal Goals defined by LTLf/LDLf formulas.
 


### PR DESCRIPTION
Leverage matrix functionality of Travis CI.

The .travis.yaml structure adopted is largely inspired by https://docs.travis-ci.com/user/languages/python/#using-tox-as-the-build-script